### PR TITLE
Change .deb JDK dependency to java8-sdk-headless

### DIFF
--- a/deb/run-alien.sh
+++ b/deb/run-alien.sh
@@ -10,7 +10,7 @@ echo "RPM_NAME: ${RPM_NAME}"
 # split up running of alien program to allow us to inject rpm requires into deb depends stanza of debian control file
 alien --generate --to-deb --scripts /data/build/${RPM_NAME}
 #cat "${RPM_BASENAME}/debian/control"
-sed -i -e 's/Depends: \${shlibs:Depends}/Depends: \${shlibs:Depends}, openjdk-8-jdk-headless/' "${RPM_BASENAME}/debian/control"
+sed -i -e 's/Depends: \${shlibs:Depends}/Depends: \${shlibs:Depends}, java8-sdk-headless/' "${RPM_BASENAME}/debian/control"
 #cat "${RPM_BASENAME}/debian/control"
 
 cd "${RPM_BASENAME}"

--- a/deb/run-alien.sh
+++ b/deb/run-alien.sh
@@ -10,7 +10,7 @@ echo "RPM_NAME: ${RPM_NAME}"
 # split up running of alien program to allow us to inject rpm requires into deb depends stanza of debian control file
 alien --generate --to-deb --scripts /data/build/${RPM_NAME}
 #cat "${RPM_BASENAME}/debian/control"
-sed -i -e 's/Depends: \${shlibs:Depends}/Depends: \${shlibs:Depends}, java8-sdk-headless/' "${RPM_BASENAME}/debian/control"
+sed -i -e 's/Depends: \${shlibs:Depends}/Depends: \${shlibs:Depends}, openjdk-8-jdk-headless | java8-sdk-headless/' "${RPM_BASENAME}/debian/control"
 #cat "${RPM_BASENAME}/debian/control"
 
 cd "${RPM_BASENAME}"


### PR DESCRIPTION
Allows for installing from AdoptOpenJDK.

Fixes #7