### PR TITLE
SystemD service: explicitly request thread limit

### DIFF
--- a/extra/daemon/nexus-repository-manager.service
+++ b/extra/daemon/nexus-repository-manager.service
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Type=forking
 LimitNOFILE=65536
+TasksMax=300
 ExecStart=/opt/sonatype/nexus3/bin/nexus start
 ExecStop=/opt/sonatype/nexus3/bin/nexus stop
 User=nexus3


### PR DESCRIPTION
Nexus can spawn a great many background jobs in different threadpools (e.g. Quartz jobs, ElasticSearch).
On smaller vServers, this can surpass a (low-ish) default thread limit, leading to `java.lang.OutOfMemoryError: unable to create new native thread`
This is a symptom of SystemD enforcing resource limits.

The number `300` is loosely based on observed values for server-wide threadcounts on a small team server
(184 threads server-wide, including non-Nexus processes, ), with a lot of margin.

The server where we ran into this problem had a default per-process thread limit of 105, 
and a server-wide process-limit of 500, so this is a good middle-ground.

closes #18