### PR TITLE
support building via local BUNDLE_FILE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ BUNDLE_FILE := nexus-$(VERSION)-unix.tar.gz
 FETCH_URL ?= "http://download.sonatype.com/nexus/3/$(BUNDLE_FILE)"
 
 # skip download and use local build/$(BUNDLE_FILE)
+# save bandwidth if you have build/* artifacts present, or workaround
+# upstream connectivity issues.
 SKIP_FETCH ?= false
 
 RHEL_VERSION ?= 7

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ BUNDLE_FILE := nexus-$(VERSION)-unix.tar.gz
 
 FETCH_URL ?= "http://download.sonatype.com/nexus/3/$(BUNDLE_FILE)"
 
+# skip download and use local build/$(BUNDLE_FILE)
+SKIP_FETCH ?= false
+
 RHEL_VERSION ?= 7
 # The release of the RPM package
 PKG_RELEASE ?= 1.el$(RHEL_VERSION)
@@ -79,8 +82,10 @@ endif
 
 # retrieve the original bundle from FETCH_URL
 $(BUILDDIR)/$(BUNDLE_FILE):
+ifeq ($(SKIP_FETCH),false)
 	@ echo "fetching bundle from $(FETCH_URL)"
 	@ curl -s -L -k -f -o $@ $(FETCH_URL)
+endif
 
 # create RPM subdirectories
 $(rpm_subdirs):

--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ $ make docker-all
 $ VERSION=3.15.2-01 make docker-all
 ```
 
+Build the RPM in a docker container.  The RPM will be written to `build/`.
+Skip download and use local build/BUNDLE_FILE.
+
+```
+$ SKIP_FETCH=true make docker
+```
+
 Use the `make help` command to see more options.
 
 Tweaks made to the Application

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ $ VERSION=3.15.2-01 make docker-all
 ```
 
 Build the RPM in a docker container.  The RPM will be written to `build/`.
-Skip download and use local build/BUNDLE_FILE.
+Skip download and use local build/BUNDLE_FILE. Useful if cached build
+artifacts are unavailable upstream.
 
 ```
 $ SKIP_FETCH=true make docker


### PR DESCRIPTION
recently had an edge case where the tarbal artifact existed locally from a prior download but was not available for download. there's probably a better way to handle this, but added a simple variable hook to use local artifact if it already exists.

```shell
SKIP_FETCH=true make docker
```