### PR TITLE
Workaround EOL CentOS mirror.

### DIFF
--- a/rpm/Dockerfile
+++ b/rpm/Dockerfile
@@ -1,6 +1,11 @@
 FROM       jswank/centos-rpm:7
 MAINTAINER Jason Swank <jswank@sonatype.com>
 
+# workaround missing EOL CentOS mirrors. see: https://github.com/sonatype-nexus-community/nexus-repository-installer/issues/37
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
 RUN yum -y install expect
 
 # force sha256 signature of rpm, instead of old default of sha1 used by CentOS7


### PR DESCRIPTION
Workaround EOL CentOS mirror.
 
Better long term fix is to remove use of CentOS.

Thanks @brandan-schmitz 

Fixes Issue #37