### PR TITLE
Exclude arch specific jdk folder from noarch package 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,7 @@ APP = nexus-repository-manager
 VERSION ?= $(shell cat version-to-build.txt)
 
 # the name of the original bundle file
-#BUNDLE_FILE := $(APP)-$(VERSION)-unix.tar.gz
-BUNDLE_FILE := nexus-$(VERSION)-unix.tar.gz
+BUNDLE_FILE := nexus-unix-x86-64-$(VERSION).tar.gz
 
 FETCH_URL ?= "http://download.sonatype.com/nexus/3/$(BUNDLE_FILE)"
 

--- a/rpm/nexus-repository-manager.spec
+++ b/rpm/nexus-repository-manager.spec
@@ -42,6 +42,7 @@ rsync -a ${RPM_PACKAGE_NAME}-${RPM_PACKAGE_VERSION}/sonatype-work/nexus3/ %{buil
 #patch config
 perl -p -i -e 's/#run_as_user=""/run_as_user="nexus3"/' %{buildroot}/opt/sonatype/nexus3/bin/nexus
 perl -p -i -e 's/\.\.\/sonatype-work/\/opt\/sonatype\/sonatype-work/g' %{buildroot}/opt/sonatype/nexus3/bin/nexus.vmoptions
+perl -p -i -e 's/^EMBEDDED_JDK/#EMBEDDED_JDK/' %{buildroot}/opt/sonatype/nexus3/bin/nexus 
 
 mkdir -p %{buildroot}/etc/systemd/system
 ln -sf /opt/sonatype/nexus3/extra/daemon/%{service_name} %{buildroot}/etc/systemd/system/%{service_name}
@@ -105,6 +106,8 @@ fi
 /opt/sonatype/sonatype-work/nexus3
 
 %changelog
+* Thu Mar 27 2025 Frank Vissing <lunarfs@hotmail.com>
+exclude jdk bin folder from package, soley rely on dependency
 * Thu Aug 08 2024 Dan Rollo <drollo@sonatype.com>
 require jdk 17.
 * Thu Mar 05 2020 Dan Rollo <drollo@sonatype.com>

--- a/rpm/nexus-repository-manager.spec
+++ b/rpm/nexus-repository-manager.spec
@@ -35,12 +35,12 @@ cd ${RPM_PACKAGE_NAME}-${RPM_PACKAGE_VERSION}
 rm -rf %{buildroot}
 mkdir -p %{buildroot}/opt/sonatype/nexus3
 mkdir -p %{buildroot}/opt/sonatype/sonatype-work/nexus3
-rsync -a ${RPM_PACKAGE_NAME}-${RPM_PACKAGE_VERSION}/nexus-$(echo ${RPM_PACKAGE_VERSION} | tr '_' '-')/ %{buildroot}/opt/sonatype/nexus3
+rsync -a --exclude 'jdk' ${RPM_PACKAGE_NAME}-${RPM_PACKAGE_VERSION}/nexus-$(echo ${RPM_PACKAGE_VERSION} | tr '_' '-')/ %{buildroot}/opt/sonatype/nexus3
 rsync -a ${RPM_PACKAGE_NAME}-${RPM_PACKAGE_VERSION}/extra %{buildroot}/opt/sonatype/nexus3/
 rsync -a ${RPM_PACKAGE_NAME}-${RPM_PACKAGE_VERSION}/sonatype-work/nexus3/ %{buildroot}/opt/sonatype/sonatype-work/nexus3
 
 #patch config
-perl -p -i -e 's/#run_as_user=""/run_as_user="nexus3"/' %{buildroot}/opt/sonatype/nexus3/bin/nexus.rc
+perl -p -i -e 's/#run_as_user=""/run_as_user="nexus3"/' %{buildroot}/opt/sonatype/nexus3/bin/nexus
 perl -p -i -e 's/\.\.\/sonatype-work/\/opt\/sonatype\/sonatype-work/g' %{buildroot}/opt/sonatype/nexus3/bin/nexus.vmoptions
 
 mkdir -p %{buildroot}/etc/systemd/system
@@ -98,7 +98,7 @@ fi
 /opt/sonatype/nexus3
 %dir %config(noreplace) /opt/sonatype/nexus3/extra
 %dir %config(noreplace) /opt/sonatype/nexus3/etc
-%config(noreplace) /opt/sonatype/nexus3/bin/nexus.rc
+%config(noreplace) /opt/sonatype/nexus3/bin/nexus
 %config(noreplace) /opt/sonatype/nexus3/bin/nexus.vmoptions
 %config /opt/sonatype/nexus3/extra/daemon/%{service_name}
 %defattr(-,nexus3,nexus3)


### PR DESCRIPTION
The noarch package already have a dependency on the java package, no need to have an embedded jdk here
also remove the EMBEDDED_JDK from the nexus3 script as it only creates noise under startup